### PR TITLE
remove MSVC CMAKE_CXX_FLAGS and /MT flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,14 +73,6 @@ add_definitions(-D__USE_XOPEN2K8)
 # compile
 if(MSVC)
   add_definitions(-DDMLC_USE_CXX11)
-  foreach(flag_var
-        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    if(${flag_var} MATCHES "/MD")
-      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-    endif(${flag_var} MATCHES "/MD")
-  endforeach(flag_var)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 else(MSVC)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   include(CheckCXXCompilerFlag)

--- a/src/config.cc
+++ b/src/config.cc
@@ -39,7 +39,7 @@ class Tokenizer {
     tok->buf.clear();
     tok->is_string = false;
     char ch;
-    while ( (ch = PeekChar()) != EOF && state_ != kFinish ) {
+    while ( (ch = PeekChar()) != static_cast<char>(EOF) && state_ != kFinish ) {
       switch (ch) {
       case ' ': case '\t': case '\n': case '\r':
         if (state_ == kToken) {
@@ -70,7 +70,7 @@ class Tokenizer {
         break;
       }
     }
-    return PeekChar() != EOF;
+    return PeekChar() != static_cast<char>(EOF);
   }
 
   void ParseString(string* tok) {
@@ -87,7 +87,7 @@ class Tokenizer {
             throw TokenizeError("error parsing escape characters");
           }
           break;
-        case '\n': case '\r': case EOF:
+        case '\n': case '\r': case static_cast<char>(EOF):
           throw TokenizeError("quotation mark is not closed");
         default:
           *tok += ch;
@@ -101,7 +101,7 @@ class Tokenizer {
   void ParseComments() {
     char ch;
     while ( (ch = PeekChar()) ) {
-      if (ch == '\n' || ch == '\r' || ch == EOF) {
+      if (ch == '\n' || ch == '\r' || ch == static_cast<char>(EOF)) {
         break;  // end of comment
       }
       EatChar();  // ignore all others


### PR DESCRIPTION
add static_cast<char>(EOF) to fix:
> warning: comparison of constant -1 with expression of type 'char' is always true [-Wtautological-constant-out-of-range-compare]